### PR TITLE
fix:compiler version

### DIFF
--- a/contracts/Lottery.sol
+++ b/contracts/Lottery.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.12;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/utils/Strings.sol";
 
@@ -63,7 +63,7 @@ contract Lottery {
      * @return index of the player within our list 
      */
     function random() private view returns (uint) {
-        return uint(keccak256(abi.encodePacked(block.difficulty, block.timestamp, players)));
+        return uint(keccak256(abi.encodePacked(block.prevrandao, block.timestamp, players)));
     }
 
     /**


### PR DESCRIPTION
When I compile the Smart Contract, It gives the following error and warning:
1. ParserError: Source file requires a different compiler version (current compiler is 0.8.12+commit.f00d7308.Emscripten.clang) - note that nightly builds are considered to be strictly less than the released version.

2. Warning: Since the VM version Paris, "difficulty" was replaced by "prevrandao", which now returns a random number based on the beacon chain.
I have fixed the error and warning. Please review and merge it.